### PR TITLE
面接官用の面接日程一覧ページを作る

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -31,3 +31,9 @@
   vertical-align: middle;
   text-align: center;
 }
+
+
+/* interview list */
+.interview-list {
+  margin: 10px 0;
+}

--- a/app/views/interviews/_other_index.html.erb
+++ b/app/views/interviews/_other_index.html.erb
@@ -1,8 +1,11 @@
 <h2>Current interview date</h2>
-<div>ここに面談日時を載せる</div>
+<div>ここに現在の面談日時を載せる</div>
+<hr>
 <div>
-  <p>変更する場合は以下から選択</p>
+  <p>面談日程を変更する場合は以下から選択してください。</p>
 <% @interviews.each do |interview| %>
-  <%= link_to interview.interview_date.strftime('%Y年%m月%d日 %H時%M分'), "#", class: "btn btn-success" %><br>
+  <div class="interview-list">
+    <%= link_to interview.interview_date.strftime('%Y年%m月%d日 %H時%M分'), "#", class: "btn btn-success" %>
+  </div>
 <% end %>
 </div>

--- a/app/views/interviews/_other_index.html.erb
+++ b/app/views/interviews/_other_index.html.erb
@@ -1,0 +1,8 @@
+<h2>Current interview date</h2>
+<div>ここに面談日時を載せる</div>
+<div>
+  <p>変更する場合は以下から選択</p>
+<% @interviews.each do |interview| %>
+  <%= link_to interview.interview_date.strftime('%Y年%m月%d日 %H時%M分'), "#", class: "btn btn-success" %><br>
+<% end %>
+</div>

--- a/app/views/interviews/_self_index.html.erb
+++ b/app/views/interviews/_self_index.html.erb
@@ -1,0 +1,21 @@
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th scope="col">Date</th>
+      <th scope="col">State</th>
+      <th scope="col" colspan="2"></th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @interviews.each do |interview| %>
+    <tr>
+      <td><%= interview.interview_date.strftime('%Y年%m月%d日 %H時%M分') %></td>
+      <td><%= interview.status %></td>
+      <td><%= link_to "Edit", edit_user_interview_path(@user, interview), class: "btn btn-info" %></td>
+      <td><%= link_to "Delete", user_interview_path(@user,interview), method: :delete, class: "btn btn-danger" %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+<br>
+<%= link_to "Create new interview", new_user_interview_path, class: "btn btn-primary" %><br><br>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,23 +1,7 @@
 <h1><%= @user.name %>'s interview list</h1>
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th scope="col">Date</th>
-      <th scope="col">State</th>
-      <th scope="col" colspan="2"></th>
-    </tr>
-  </thead>
-  <tbody>
-  <% @interviews.each do |interview| %>
-    <tr>
-      <td><%= interview.interview_date.strftime('%Y年%m月%d日 %H時%M分') %></td>
-      <td><%= interview.status %></td>
-      <td><%= link_to "Edit", edit_user_interview_path(@user, interview), class: "btn btn-info" %></td>
-      <td><%= link_to "Delete", user_interview_path(@user,interview), method: :delete, class: "btn btn-danger" %></td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>
-<br>
-<%= link_to "Create new interview", new_user_interview_path, class: "btn btn-primary" %><br><br>
+<% if current_user == @user %>
+  <%= render 'interviews/self_index' %>
+<% else %>
+  <%= render 'interviews/other_index' %>
+<% end %>


### PR DESCRIPTION
やりたかったこと
---

- 他人のinterviews#indexページにアクセスいた場合、面談日程の一覧を表示

やったこと
----

- interviews#indexのビューを分岐（ログイン中のユーザーと表示するページのユーザーが一致するかどうかで表示する部分テンプレートを分岐）
- 自分のindexページでは前回までの面談日程設定ページを表示、他人のindexページでは設定された面談日程の一覧をボタンで表示（アクションは未設定）


動作確認方法
---

- heroku ( https://e-navigator-mashvalue1.herokuapp.com/ )にアクセスし、他のユーザーのinterview listボタンからindexページに移動。
- そのユーザーが設定した面談日程が表示されていることを確認する。

その他
---

何か分からない点や、ここ頑張りましたなどあればこちらに書いてください。
