### PR TITLE
面談日程を承認or拒否できるようにする

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,6 @@
 class InterviewsController < ApplicationController
   before_action :set_user, except: :destroy
-  before_action :set_interview, only: [:edit, :update, :destroy]
+  before_action :set_interview, only: [:edit, :update, :destroy, :setup]
 
   def index
     @interviews = @user.interviews.order("interview_date")
@@ -36,6 +36,17 @@ class InterviewsController < ApplicationController
     @interview.destroy
     flash[:success] = "Interview deleted."
     redirect_to user_interviews_url
+  end
+
+  def setup
+    others = Interview.where(user_id: @user.id).where.not(id: params[:id])
+    if @interview.update(status: 1)
+      others.update_all(status: 2)
+      flash[:success] = "Interview has been set."
+      redirect_to root_url
+    else
+      render 'edit'
+    end
   end
 
   private

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,5 @@
 class InterviewsController < ApplicationController
-  before_action :set_user, except: :destroy
+  before_action :set_user, except: [:destroy, :setup]
   before_action :set_interview, only: [:edit, :update, :destroy, :setup]
 
   def index
@@ -39,11 +39,11 @@ class InterviewsController < ApplicationController
   end
 
   def setup
-    others = Interview.where(user_id: @user.id).where.not(id: params[:id])
+    others = Interview.where(user_id: params[:user_id]).where.not(id: params[:id])
     if @interview.update(status: 1)
       others.update_all(status: 2)
       flash[:success] = "Interview has been set."
-      redirect_to root_url
+      redirect_to user_interviews_url(params[:user_id])
     else
       render 'edit'
     end

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -9,6 +9,6 @@ module InterviewsHelper
   end
 
   def date_format(interview)
-    return interview.interview_date.strftime("%Y年%m月%d日 %H時%M分")
+    return interview.interview_date.strftime("%Y年%m月%d日 %H時%M分") if interview
   end
 end

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,2 +1,10 @@
 module InterviewsHelper
+
+  def get_current_interview(user)
+    Interview.find_by(user_id: user.id, status: 1)
+  end
+
+  def check_current_interview(interview)
+    interview ? interview.interview_date.strftime("%Y年%m月%d日 %H時%M分") + "に面談が設定されています" : "現在面談は設定されていません"
+  end
 end

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -5,6 +5,10 @@ module InterviewsHelper
   end
 
   def check_current_interview(interview)
-    interview ? interview.interview_date.strftime("%Y年%m月%d日 %H時%M分") + "に面談が設定されています" : "現在面談は設定されていません"
+    interview ? "#{date_format(interview)}に面談が設定されています" : "現在面談は設定されていません"
+  end
+
+  def date_format(interview)
+    return interview.interview_date.strftime("%Y年%m月%d日 %H時%M分")
   end
 end

--- a/app/views/interviews/_other_index.html.erb
+++ b/app/views/interviews/_other_index.html.erb
@@ -1,11 +1,13 @@
 <h2>Current interview date</h2>
-<div>ここに現在の面談日時を載せる</div>
+<div>
+  <%= check_current_interview(get_current_interview(@user)) %>
+</div>
 <hr>
 <div>
   <p>面談日程を変更する場合は以下から選択してください。</p>
 <% @interviews.each do |interview| %>
   <div class="interview-list">
-    <%= link_to interview.interview_date.strftime('%Y年%m月%d日 %H時%M分'), "#", class: "btn btn-success" %>
+    <%= link_to interview.interview_date.strftime('%Y年%m月%d日 %H時%M分'), "#", class: "btn btn-success" unless interview.status == "accepted" %>
   </div>
 <% end %>
 </div>

--- a/app/views/interviews/_other_index.html.erb
+++ b/app/views/interviews/_other_index.html.erb
@@ -7,7 +7,8 @@
   <p>面談日程を変更する場合は以下から選択してください。</p>
 <% @interviews.each do |interview| %>
   <div class="interview-list">
-    <%= link_to interview.interview_date.strftime('%Y年%m月%d日 %H時%M分'), "#", class: "btn btn-success" unless interview.status == "accepted" %>
+    <% date = date_format(interview) %>
+    <%= link_to "#{date}", setup_user_interview_path(@user, interview), class: "btn btn-success" unless interview.status == "accepted" %>
   </div>
 <% end %>
 </div>

--- a/app/views/interviews/_other_index.html.erb
+++ b/app/views/interviews/_other_index.html.erb
@@ -8,7 +8,7 @@
 <% @interviews.each do |interview| %>
   <div class="interview-list">
     <% date = date_format(interview) %>
-    <%= link_to "#{date}", setup_user_interview_path(@user, interview), class: "btn btn-success" unless interview.status == "accepted" %>
+    <%= link_to "#{date}", setup_user_interview_path(@user, interview), method: :patch, data: { confirm: "面談を#{date}に設定しますか？" }, class: "btn btn-success" unless interview.status == "accepted" %>
   </div>
 <% end %>
 </div>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,4 +1,8 @@
-<h1><%= @user.name %>'s interview list</h1>
+<% if @user.name.present? %>
+  <h1><%= @user.name %>'s interview list</h1>
+<% else %>
+  <h1><%= @user.email %>'s interview list</h1>
+<% end %>
 
 <% if current_user == @user %>
   <%= render 'interviews/self_index' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,7 +20,7 @@
       <td><%= calc_age(user) if user.birthday %></td>
       <td><%= user.sex %></td>
       <td><%= user.school %></td>
-      <td>ここに面談日程</td>
+      <td><%= date_format(get_current_interview(user)) %></td>
       <td><%= link_to "Interview list", user_interviews_path(user), class: "btn btn-primary" %></td>
     </tr>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
   resources :users do
-    resources :interviews
+    resources :interviews do
+      member do
+        patch :setup
+      end
+    end
   end
   root "users#index"
 end


### PR DESCRIPTION
やりたかったこと
---

- 面談の承認
- 承認した面談の日時が過去の場合は編集画面へ遷移
- 面談が正常に承認された場合は他の面談は却下状態に更新

...

やったこと
----

- 面談承認のためのactionを定義
- 面談日時を選択した場合の確認メッセージの定義
- 面談日時更新処理の実装
- 面談日時更新の成否に応じた画面遷移
- 設定された面談日時をview側に反映


動作確認方法
---

- https://e-navigator-mashvalue1.herokuapp.com/ にアクセスしサインイン
- interview listからいずれかのユーザーの面談日時の一覧ページに移動
- いずれかの日時を選択すると確認メッセージが表示されるかを確認
- 選択した日時が未来の場合、user一覧ページにリダイレクトされ、該当ユーザーの面談日時が表示されていることを確認
- 選択した日時が過去の場合、エラーメッセージが表示され、日時編集画面へ移動することを確認


その他
---

何か分からない点や、ここ頑張りましたなどあればこちらに書いてください。
